### PR TITLE
Add basic support for history features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,8 @@ Metrics/BlockLength:
 
 Gemspec/RequiredRubyVersion:
   Enabled: false
+
+Metrics/BlockLength:
+  ExcludedMethods: ['describe', 'context']
+  Exclude:
+    - 'linenoise.gemspec'

--- a/ext/linenoise/line_noise.c
+++ b/ext/linenoise/line_noise.c
@@ -1086,6 +1086,14 @@ static void freeHistory(void) {
     }
 }
 
+// Allocate fresh memory for history and reset history length.
+static void resetHistory(void) {
+    history = malloc(sizeof(char*)*history_max_len);
+    if (history == NULL) return;
+    memset(history, 0, (sizeof(char*)*history_max_len));
+    history_len = 0;
+}
+
 /* At exit we'll try to fix the terminal to the initial conditions. */
 static void linenoiseAtExit(void) {
     disableRawMode(STDIN_FILENO);
@@ -1106,9 +1114,8 @@ int linenoiseHistoryAdd(const char *line) {
 
     /* Initialization on first call. */
     if (history == NULL) {
-        history = malloc(sizeof(char*)*history_max_len);
+        resetHistory();
         if (history == NULL) return 0;
-        memset(history,0,(sizeof(char*)*history_max_len));
     }
 
     /* Don't add duplicated lines. */
@@ -1198,4 +1205,13 @@ int linenoiseHistoryLoad(const char *filename) {
     }
     fclose(fp);
     return 0;
+}
+
+int linenoiseHistorySize(void) {
+    return history_len;
+}
+
+void linenoiseHistoryClear(void) {
+    freeHistory();
+    resetHistory();
 }

--- a/ext/linenoise/line_noise.h
+++ b/ext/linenoise/line_noise.h
@@ -62,6 +62,8 @@ int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);
+int linenoiseHistorySize();
+void linenoiseHistoryClear();
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);

--- a/ext/linenoise/linenoise.c
+++ b/ext/linenoise/linenoise.c
@@ -1,6 +1,8 @@
 #include <ruby.h>
 #include "line_noise.h"
 
+static VALUE mLinenoise;
+
 static VALUE
 linenoise_linenoise(VALUE self, VALUE prompt)
 {
@@ -18,14 +20,98 @@ linenoise_linenoise(VALUE self, VALUE prompt)
     return result;
 }
 
+static VALUE
+hist_set_max_len(VALUE self, VALUE len)
+{
+    linenoiseHistorySetMaxLen(NUM2INT(len));
+    return len;
+}
+
+static VALUE
+hist_push(VALUE self, VALUE str)
+{
+    linenoiseHistoryAdd(StringValueCStr(str));
+    return self;
+}
+
+static VALUE
+hist_push_method(int argc, VALUE *argv, VALUE self)
+{
+    VALUE str;
+
+    while (argc--) {
+        str = *argv++;
+        linenoiseHistoryAdd(StringValueCStr(str));
+    }
+    return self;
+}
+
+static VALUE
+hist_save(VALUE self, VALUE filename)
+{
+    char *file = StringValueCStr(filename);
+
+    if (linenoiseHistorySave(file) == -1) {
+        rb_raise(rb_eArgError,
+                 "couldn't save Linenoise history to file '%s'", file);
+    }
+    return filename;
+}
+
+
+static VALUE
+hist_load(VALUE self, VALUE filename)
+{
+    char *file = StringValueCStr(filename);
+
+    if (linenoiseHistoryLoad(file) == -1) {
+        rb_raise(rb_eArgError,
+                 "couldn't load Linenoise history from file '%s'", file);
+    }
+    return filename;
+}
+
+static VALUE
+hist_length(VALUE self)
+{
+    return INT2NUM(linenoiseHistorySize());
+}
+
+static VALUE
+hist_clear(VALUE self)
+{
+    linenoiseHistoryClear();
+    return self;
+}
+
 void
 Init_linenoise(void)
 {
-    VALUE mLinenoise = rb_define_module("Linenoise");
+    VALUE history;
+
+    mLinenoise = rb_define_module("Linenoise");
     rb_define_module_function(mLinenoise, "linenoise",
                               linenoise_linenoise, 1);
     rb_define_alias(rb_singleton_class(mLinenoise), "readline", "linenoise");
 
     /* Version string of Linenoise. */
     rb_define_const(mLinenoise, "VERSION", rb_str_new_cstr("1.0"));
+
+    history = rb_obj_alloc(rb_cObject);
+    rb_extend_object(history, rb_mEnumerable);
+    rb_define_singleton_method(history, "max_len=", hist_set_max_len, 1);
+    rb_define_singleton_method(history, "<<", hist_push, 1);
+    rb_define_singleton_method(history, "push", hist_push_method, -1);
+    rb_define_singleton_method(history, "save", hist_save, 1);
+    rb_define_singleton_method(history, "load", hist_load, 1);
+    rb_define_singleton_method(history, "size", hist_length, 0);
+    rb_define_singleton_method(history, "clear", hist_clear, 0);
+
+    /*
+     * The history buffer. It extends Enumerable module, so it behaves
+     * just like an array.
+     * For example, gets the fifth content that the user input by
+     * HISTORY[4].
+     */
+    rb_define_const(mLinenoise, "HISTORY", history);
 }

--- a/spec/linenoise_history_spec.rb
+++ b/spec/linenoise_history_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Linenoise::HISTORY do
+  after { subject.clear }
+
+  describe "#push" do
+    it "appends to history" do
+      subject.max_len = 3
+
+      subject << "123"
+      expect(subject.size).to eq(1)
+
+      subject.push("1", "2")
+      expect(subject.size).to eq(3)
+
+      subject.push("3", "4")
+      expect(subject.size).to eq(3)
+    end
+  end
+
+  describe "#save" do
+    let(:filename) { 'history_file' }
+
+    after { File.delete(filename) }
+
+    it "saves history" do
+      expect(File.exist?(filename)).not_to be_truthy
+      subject.save(filename)
+      expect(File.exist?(filename)).to be_truthy
+    end
+  end
+
+  describe "#load" do
+    let(:filename) { 'history_file' }
+
+    before do
+      File.open(filename, 'w+') { |f| f.puts("1\n2\n") }
+    end
+
+    after { File.delete(filename) }
+
+    it "loads history" do
+      subject.load(filename)
+      expect(subject.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
I also had to tweak the linenoise library to expose some private functions and
add a function for clearing history, so it's possible to test the library.