### PR TITLE
Help for installation from non-"standard" paths

### DIFF
--- a/ext/linenoise/extconf.rb
+++ b/ext/linenoise/extconf.rb
@@ -1,2 +1,4 @@
 require 'mkmf'
+dir_config('linenoise')
+have_header('linenoise.h')
 create_makefile('linenoise/linenoise')


### PR DESCRIPTION
Hi there,

Without these lines it's a pain to install when linenoise isn't where Rubygems/the Makefile expect it to be.

Regards,
iain